### PR TITLE
Fix JSON plan parsing error handling

### DIFF
--- a/python/mille_viz/utils.py
+++ b/python/mille_viz/utils.py
@@ -20,7 +20,7 @@ def parse_tf_plan(plan_file_path: str) -> Dict[str, Any]:
         
     Raises:
         FileNotFoundError: If the plan file doesn't exist
-        json.JSONDecodeError: If the file contains invalid JSON
+        ValueError: If the file contains invalid JSON
     """
     try:
         with open(plan_file_path, 'r', encoding='utf-8') as f:
@@ -29,7 +29,7 @@ def parse_tf_plan(plan_file_path: str) -> Dict[str, Any]:
     except FileNotFoundError:
         raise FileNotFoundError(f"Terraform plan file not found: {plan_file_path}")
     except json.JSONDecodeError as e:
-        raise json.JSONDecodeError(f"Invalid JSON in plan file: {e}")
+        raise ValueError(f"Invalid JSON in plan file {plan_file_path}: {e}") from e
 
 
 def get_supported_providers() -> List[str]:


### PR DESCRIPTION
## Summary
- raise `ValueError` when failing to decode plan JSON
- update the docstring for `parse_tf_plan`

## Testing
- `python -m compileall -q python/mille_viz`
- `python test_diagrams.py` *(fails: ModuleNotFoundError: No module named 'diagrams')*

------
https://chatgpt.com/codex/tasks/task_e_6845d831c3f8832ca2ab7c6ac9f5ffad