### PR TITLE
Update license classifier

### DIFF
--- a/docs/tech_spec/15-development-environment.md
+++ b/docs/tech_spec/15-development-environment.md
@@ -154,7 +154,7 @@ version = "0.1.0"
 description = "Terraform Plan Visualization Tools"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 dependencies = [
     "diagrams>=0.23.3",
     "pydantic>=1.9.0",

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary
- update Python setup classifier to Apache Software License
- fix docs to reflect Apache license

## Testing
- `pytest -q` *(fails: No module named 'diagrams')*

------
https://chatgpt.com/codex/tasks/task_e_6846522cef04832ca80501aee3c87c0a