### PR TITLE
Fix JSONDecodeError handling

### DIFF
--- a/python/mille_viz/utils.py
+++ b/python/mille_viz/utils.py
@@ -20,7 +20,7 @@ def parse_tf_plan(plan_file_path: str) -> Dict[str, Any]:
         
     Raises:
         FileNotFoundError: If the plan file doesn't exist
-        ValueError: If the file contains invalid JSON
+        json.JSONDecodeError: If the file contains invalid JSON
     """
     try:
         with open(plan_file_path, 'r', encoding='utf-8') as f:
@@ -29,7 +29,9 @@ def parse_tf_plan(plan_file_path: str) -> Dict[str, Any]:
     except FileNotFoundError:
         raise FileNotFoundError(f"Terraform plan file not found: {plan_file_path}")
     except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid JSON in plan file {plan_file_path}: {e}") from e
+        raise json.JSONDecodeError(
+            f"Invalid JSON in plan file: {e.msg}", e.doc, e.pos
+        )
 
 
 def get_supported_providers() -> List[str]:


### PR DESCRIPTION
## Summary
- tweak parse_tf_plan to rethrow JSON decode errors

## Testing
- `python python/test_diagrams.py` *(fails: cannot import name 'Subnet' from diagrams.aws.network)*

------
https://chatgpt.com/codex/tasks/task_e_6846523251a4832c8025d447770af15b